### PR TITLE
Make period `p5` more validly parametric

### DIFF
--- a/LifeCycleModel35EZsemi.m
+++ b/LifeCycleModel35EZsemi.m
@@ -28,6 +28,9 @@
 % the price of the house
 
 % To be able to solve such a big problem, I switched to 5 year model period.
+% Note that p5 must be at least 3 (for Farmer-Toda) so years-owned >= 2.
+% p5 must be at most 15 (for kappa_j labor productivity evolutions).
+p5=5; % model period, in years (just used this to modify some parameters from annual to model period)
 
 %% How does VFI Toolkit think about this?
 %
@@ -43,14 +46,14 @@
 % period is ages 20-24, and last period is ages 75-79.
 
 Params.agejshifter=19; % Age 20 minus one. Makes keeping track of actual age easy in terms of model age
-Params.J=(79-Params.agejshifter)/5; % =81, Number of period in life-cycle
+Params.J=ceil((79-Params.agejshifter)/p5);  % =60/p5, Number of period in life-cycle
 
 % Grid sizes to use
 n_d=[11,101,5]; % Decisions: riskyshare, savings, buyhouse (note, SemiExoStateFn hardcodes that buyhouse is 5 points)
 n_a=[3,21]; % Endogenous housing and asset holdings
-n_semiz=[5,5,6,3]; % Semi-exog: house prices before/after purchase, years since purchase (one minus this is the duration of mortgages in model periods), and downpayment
+n_semiz=[5,5,ceil(30/p5),3]; % Semi-exog: house prices before/after purchase, years since purchase (one minus this is the 30y duration of mortgages in model periods), and downpayment
 n_z=7; % Exogenous labor productivity units shock
-n_u=5; % Between period i.i.d. shock
+n_u=p5; % Between period i.i.d. shock
 N_j=Params.J; % Number of periods in finite horizon
 
 vfoptions.riskyasset=1; % riskyasset aprime(d,u)
@@ -81,8 +84,6 @@ simoptions.refine_d=vfoptions.refine_d;
 
 %% Parameters
 
-p5=5; % model period, in years (just used this to modify some parameters from annual to model period)
-
 % Housing
 Params.f_htc=0; % transaction cost of buying/selling house (is a percent of h+prime)
 % Params.minhouse % set below, is the minimum value of house that can be purchased
@@ -100,9 +101,9 @@ Params.sigma_h=0.5; % Relative importance of housing services (vs consumption) i
 Params.w=1; % Wage
 
 % Asset returns
-Params.r=0.05^p5; % Rate of return on risk free asset
+Params.r=(1.05^p5)-1; % Rate of return on risk free asset
 % u is the stochastic component of the excess returns to the risky asset
-Params.rp=0.03^p5; % Mean excess returns to the risky asset (so the mean return of the risky asset will be r+rp)
+Params.rp=(1.03^p5)-1; % Mean excess returns to the risky asset (so the mean return of the risky asset will be r+rp)
 Params.sigma_u=0.025; % Standard deviation of innovations to the risky asset
 Params.rho_u=0; % Asset return risk component is modeled as iid (if you regresse, e.g., the percent change in S&P500 on it's one year lag you get a coefficient of essentially zero)
 [u_grid, pi_u]=discretizeAR1_FarmerToda(Params.rp,Params.rho_u,Params.sigma_u,n_u);
@@ -110,13 +111,17 @@ pi_u=pi_u(1,:)'; % This is iid
 
 % Demographics
 Params.agej=1:1:Params.J; % Is a vector of all the agej: 1,2,3,...,J
-Params.Jr=10; % Age 65 (period 10 is ages 65-69)
+Params.Jr=ceil((65-Params.agejshifter)/p5); % Age 65 (period 10 is ages 65-69 in the 5 year case)
 
 % Pensions
 Params.pension=0.4; % Increased to be greater than rental costs
 
 % Age-dependent labor productivity units
-Params.kappa_j=[linspace(0.5,2,Params.Jr-3),linspace(2,1,2),zeros(1,Params.J-Params.Jr+1)];
+if Params.Jr>5
+    Params.kappa_j=[linspace(0.5,2,Params.Jr-3),linspace(2,1,2),zeros(1,Params.J-Params.Jr+1)];
+else
+    Params.kappa_j=[linspace(0.5,2,Params.Jr-2),ones(1,1),zeros(1,Params.J-Params.Jr+1)];
+end
 % Exogenous shock process: AR1 on labor productivity units
 Params.rho_z=0.9;
 Params.sigma_epsilon_z=0.03;
@@ -131,9 +136,10 @@ Params.dj=[0.006879, 0.000463, 0.000307, 0.000220, 0.000184, 0.000172, 0.000160,
     0.000894, 0.000962, 0.001005, 0.001016, 0.001003, 0.000983, 0.000967, 0.000960, 0.000970, 0.000994, 0.001027, 0.001065, 0.001115, 0.001154, 0.001209, 0.001271, 0.001351, 0.001460, 0.001603, 0.001769, 0.001943, 0.002120, 0.002311, 0.002520, 0.002747, 0.002989, 0.003242, 0.003512, 0.003803, 0.004118, 0.004464, 0.004837, 0.005217, 0.005591, 0.005963, 0.006346, 0.006768, 0.007261, 0.007866, 0.008596, 0.009473, 0.010450, 0.011456, 0.012407, 0.013320, 0.014299, 0.015323,...
     0.016558, 0.018029, 0.019723, 0.021607, 0.023723, 0.026143, 0.028892, 0.031988, 0.035476, 0.039238, 0.043382, 0.047941, 0.052953, 0.058457, 0.064494,...
     0.071107, 0.078342, 0.086244, 0.094861, 0.104242, 0.114432, 0.125479, 0.137427, 0.150317, 0.164187, 0.179066, 0.194979, 0.211941, 0.229957, 0.249020, 0.269112, 0.290198, 0.312231, 1.000000]; 
-% dj covers Ages 0 to 100
-Params.sj=prod(1-reshape(Params.dj(1:100),[5,20]),1); % five-year survival rates
-Params.sj=Params.sj(5:5+N_j-1); % Just the ages we are using
+Params.dj=resize(Params.dj,101+p5,FillValue=1);
+% dj covers Ages 0-100, plus extras at end to make it period-friendly
+Params.sj=prod(1-reshape(Params.dj(1:p5*ceil(101/p5)),[p5,ceil(101/p5)]),1); % p5-year survival rates
+Params.sj=Params.sj(1+ceil(20/p5):floor(20/p5)+N_j); % Just the ages we are using (20yo and up)
 Params.sj(end)=0; % In the present model the last period (j=J) value of sj is actually irrelevant
 
 %% Mortgages

--- a/LifeCycleModel35semi.m
+++ b/LifeCycleModel35semi.m
@@ -28,6 +28,8 @@
 % the price of the house
 
 % To be able to solve such a big problem, I switched to 5 year model period.
+% Note that p5 must be at least 3 (for Farmer-Toda) so years-owned >= 2.
+p5=5; % model period, in years (just used this to modify some parameters from annual to model period)
 
 %% How does VFI Toolkit think about this?
 %
@@ -43,14 +45,14 @@
 % period is ages 20-24, and last period is ages 75-79.
 
 Params.agejshifter=19; % Age 20 minus one. Makes keeping track of actual age easy in terms of model age
-Params.J=(79-Params.agejshifter)/5; % =81, Number of period in life-cycle
+Params.J=ceil((79-Params.agejshifter)/p5); % =81, Number of period in life-cycle
 
 % Grid sizes to use
 n_d=[11,101,5]; % Decisions: riskyshare, savings, buyhouse (note, SemiExoStateFn hardcodes that buyhouse is 5 points)
 n_a=[3,21]; % Endogenous housing and asset holdings
-n_semiz=[5,5,6,3]; % Semi-exog: house prices before/after purchase, years since purchase (one minus this is the duration of mortgages in model periods), and downpayment
+n_semiz=[5,5,ceil(30/p5),3]; % Semi-exog: house prices before/after purchase, years since purchase (one minus this is the 30y duration of mortgages in model periods), and downpayment
 n_z=7; % Exogenous labor productivity units shock
-n_u=5; % Between period i.i.d. shock
+n_u=p5; % Between period i.i.d. shock
 N_j=Params.J; % Number of periods in finite horizon
 
 vfoptions.riskyasset=1; % riskyasset aprime(d,u)
@@ -81,8 +83,6 @@ simoptions.refine_d=vfoptions.refine_d;
 
 %% Parameters
 
-p5=5; % model period, in years (just used this to modify some parameters from annual to model period)
-
 % Housing
 Params.f_htc=0; % transaction cost of buying/selling house (is a percent of h+prime)
 % Params.minhouse % set below, is the minimum value of house that can be purchased
@@ -100,17 +100,17 @@ Params.sigma_h=0.5; % Relative importance of housing services (vs consumption) i
 Params.w=1; % Wage
 
 % Asset returns
-Params.r=0.05^p5; % Rate of return on risk free asset
+Params.r=(1.05^p5)-1; % Rate of return on risk free asset
 % u is the stochastic component of the excess returns to the risky asset
-Params.rp=0.03^p5; % Mean excess returns to the risky asset (so the mean return of the risky asset will be r+rp)
+Params.rp=(1.03^p5)-1; % Mean excess returns to the risky asset (so the mean return of the risky asset will be r+rp)
 Params.sigma_u=0.025; % Standard deviation of innovations to the risky asset
-Params.rho_u=0; % Asset return risk component is modeled as iid (if you regresse, e.g., the percent change in S&P500 on it's one year lag you get a coefficient of essentially zero)
+Params.rho_u=0; % Asset return risk component is modeled as iid (if you regressed, e.g., the percent change in S&P500 on it's one year lag you get a coefficient of essentially zero)
 [u_grid, pi_u]=discretizeAR1_FarmerToda(Params.rp,Params.rho_u,Params.sigma_u,n_u);
 pi_u=pi_u(1,:)'; % This is iid
 
 % Demographics
 Params.agej=1:1:Params.J; % Is a vector of all the agej: 1,2,3,...,J
-Params.Jr=10; % Age 65 (period 10 is ages 65-69)
+Params.Jr=ceil((65-Params.agejshifter)/p5); % Age 65 (period 10 is ages 65-69 in the 5 year case)
 
 % Pensions
 Params.pension=0.4; % Increased to be greater than rental costs
@@ -132,8 +132,8 @@ Params.dj=[0.006879, 0.000463, 0.000307, 0.000220, 0.000184, 0.000172, 0.000160,
     0.016558, 0.018029, 0.019723, 0.021607, 0.023723, 0.026143, 0.028892, 0.031988, 0.035476, 0.039238, 0.043382, 0.047941, 0.052953, 0.058457, 0.064494,...
     0.071107, 0.078342, 0.086244, 0.094861, 0.104242, 0.114432, 0.125479, 0.137427, 0.150317, 0.164187, 0.179066, 0.194979, 0.211941, 0.229957, 0.249020, 0.269112, 0.290198, 0.312231, 1.000000]; 
 % dj covers Ages 0 to 100
-Params.sj=prod(1-reshape(Params.dj(1:100),[5,20]),1); % five-year survival rates
-Params.sj=Params.sj(5:5+N_j-1); % Just the ages we are using
+Params.sj=prod(1-reshape(Params.dj(1:p5*floor(100/p5)),[p5,floor(100/p5)]),1); % p5-year survival rates, may not reach 100 years old
+Params.sj=Params.sj(1+ceil(20/p5):ceil(20/p5)+N_j); % Just the ages we are using (20yo and up)
 Params.sj(end)=0; % In the present model the last period (j=J) value of sj is actually irrelevant
 
 %% Mortgages

--- a/LifeCycleModel35semi.m
+++ b/LifeCycleModel35semi.m
@@ -29,6 +29,7 @@
 
 % To be able to solve such a big problem, I switched to 5 year model period.
 % Note that p5 must be at least 3 (for Farmer-Toda) so years-owned >= 2.
+% p5 must be at most 15 (for kappa_j labor productivity evolutions).
 p5=5; % model period, in years (just used this to modify some parameters from annual to model period)
 
 %% How does VFI Toolkit think about this?
@@ -45,7 +46,7 @@ p5=5; % model period, in years (just used this to modify some parameters from an
 % period is ages 20-24, and last period is ages 75-79.
 
 Params.agejshifter=19; % Age 20 minus one. Makes keeping track of actual age easy in terms of model age
-Params.J=ceil((79-Params.agejshifter)/p5); % =81, Number of period in life-cycle
+Params.J=ceil((79-Params.agejshifter)/p5);  % =60/p5, Number of period in life-cycle
 
 % Grid sizes to use
 n_d=[11,101,5]; % Decisions: riskyshare, savings, buyhouse (note, SemiExoStateFn hardcodes that buyhouse is 5 points)
@@ -109,14 +110,18 @@ Params.rho_u=0; % Asset return risk component is modeled as iid (if you regresse
 pi_u=pi_u(1,:)'; % This is iid
 
 % Demographics
-Params.agej=1:1:Params.J; % Is a vector of all the agej: 1,2,3,...,J
+Params.agej=1:1:Params.J; % Is a vector of all the agej periods: 1,2,3,...,J
 Params.Jr=ceil((65-Params.agejshifter)/p5); % Age 65 (period 10 is ages 65-69 in the 5 year case)
 
 % Pensions
 Params.pension=0.4; % Increased to be greater than rental costs
 
 % Age-dependent labor productivity units
-Params.kappa_j=[linspace(0.5,2,Params.Jr-3),linspace(2,1,2),zeros(1,Params.J-Params.Jr+1)];
+if Params.Jr>5
+    Params.kappa_j=[linspace(0.5,2,Params.Jr-3),linspace(2,1,2),zeros(1,Params.J-Params.Jr+1)];
+else
+    Params.kappa_j=[linspace(0.5,2,Params.Jr-2),ones(1,1),zeros(1,Params.J-Params.Jr+1)];
+end
 % Exogenous shock process: AR1 on labor productivity units
 Params.rho_z=0.9;
 Params.sigma_epsilon_z=0.03;
@@ -131,9 +136,10 @@ Params.dj=[0.006879, 0.000463, 0.000307, 0.000220, 0.000184, 0.000172, 0.000160,
     0.000894, 0.000962, 0.001005, 0.001016, 0.001003, 0.000983, 0.000967, 0.000960, 0.000970, 0.000994, 0.001027, 0.001065, 0.001115, 0.001154, 0.001209, 0.001271, 0.001351, 0.001460, 0.001603, 0.001769, 0.001943, 0.002120, 0.002311, 0.002520, 0.002747, 0.002989, 0.003242, 0.003512, 0.003803, 0.004118, 0.004464, 0.004837, 0.005217, 0.005591, 0.005963, 0.006346, 0.006768, 0.007261, 0.007866, 0.008596, 0.009473, 0.010450, 0.011456, 0.012407, 0.013320, 0.014299, 0.015323,...
     0.016558, 0.018029, 0.019723, 0.021607, 0.023723, 0.026143, 0.028892, 0.031988, 0.035476, 0.039238, 0.043382, 0.047941, 0.052953, 0.058457, 0.064494,...
     0.071107, 0.078342, 0.086244, 0.094861, 0.104242, 0.114432, 0.125479, 0.137427, 0.150317, 0.164187, 0.179066, 0.194979, 0.211941, 0.229957, 0.249020, 0.269112, 0.290198, 0.312231, 1.000000]; 
-% dj covers Ages 0 to 100
-Params.sj=prod(1-reshape(Params.dj(1:p5*floor(100/p5)),[p5,floor(100/p5)]),1); % p5-year survival rates, may not reach 100 years old
-Params.sj=Params.sj(1+ceil(20/p5):ceil(20/p5)+N_j); % Just the ages we are using (20yo and up)
+Params.dj=resize(Params.dj,101+p5,FillValue=1);
+% dj covers Ages 0-100, plus extras at end to make it period-friendly
+Params.sj=prod(1-reshape(Params.dj(1:p5*ceil(101/p5)),[p5,ceil(101/p5)]),1); % p5-year survival rates
+Params.sj=Params.sj(1+ceil(20/p5):floor(20/p5)+N_j); % Just the ages we are using (20yo and up)
 Params.sj(end)=0; % In the present model the last period (j=J) value of sj is actually irrelevant
 
 %% Mortgages


### PR DESCRIPTION
These changes are intended to make it possible to experiment more accurately with different period lengths (as perhaps initially intended). The variable `p5` is by default a 5-year period.  However, several other aspects of the model were hard-coded to 5-year periods when they should have been parameterized by `p5`.  Moreover, the risk-free rate of return was erroneously calculated as `0.05^p5`, which meant that over a period of 5 years, it was a very small rate of return indeed!  Similarly, the excess return of a risky asset was erroneously calculated as `0.03^p5`, which is a similarly very very small excess rate of return.  The new values reflect a proper rate of return over the period.

The one change I am least sure about is at new line 55 (`% Between period i.i.d. shock`).  I presumed we could have one shock per period.  But I may be misunderstanding how to initialize `n_u`.

FYI, this runs comfortably on a machine with 256GB RAM with `p5` in the range of 6 to 10.  It starts to sweat when `p5` is 5 (about 20GB excess swapping), and it sweats profusely (about 200GB excess swapping) when `p5` is 4.  A 512GB RAM machine should handle `p5=4` without swapping (I think).